### PR TITLE
Update API and enable custom theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,22 @@
 import { useFabraConnect } from '@fabra/react-fabra-connect';
 
 function App() {
-  const { open } = useFabraConnect();
   const linkToken = <Fetch the link token from your own backend>;
+
+  const theme = {
+    colors: {
+      primary: {
+        base: #805AD5, // Default color for buttons, graphics, etc
+        hover: #553C9A, // Hover color for buttons and links
+        text: #FFFFFF, // The font color on top of the primary color
+      }
+    }
+  }
+
+  const { open } = useFabraConnect({
+    linkToken,
+    theme, // Theme is optional, will default to Fabra colors.
+  });
 
   return (
     <div className="App">

--- a/README.md
+++ b/README.md
@@ -21,13 +21,12 @@ function App() {
   }
 
   const { open } = useFabraConnect({
-    linkToken,
     theme, // Theme is optional, will default to Fabra colors.
   });
 
   return (
     <div className="App">
-      <button onClick={() => open()} />
+      <button onClick={() => open(linkToken)} />
     </div>
   );
 }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ function App() {
 
   return (
     <div className="App">
-      <button onClick={() => open(linkToken)} />
+      <button onClick={() => open()} />
     </div>
   );
 }

--- a/src/useFabraConnect.tsx
+++ b/src/useFabraConnect.tsx
@@ -23,11 +23,11 @@ export interface FabraConnect {
 
 
 export type UseFabraConnectResponse = {
-  open: (linkToken: string, customTheme?: CustomTheme) => void;
+  open: (linkToken: string) => void;
   close: () => void;
 };
 
-export const useFabraConnect = ({ linkToken, customTheme } :{ linkToken: string, customTheme?: CustomTheme}): UseFabraConnectResponse => {
+export const useFabraConnect = ({  customTheme } :{  customTheme?: CustomTheme}): UseFabraConnectResponse => {
   const [isFabraReady, setIsFabraReady] = useState<boolean>(false)
 
   const initFabra = useCallback(async () => {
@@ -36,7 +36,7 @@ export const useFabraConnect = ({ linkToken, customTheme } :{ linkToken: string,
     });
     
     setIsFabraReady(true);
-  }, [linkToken, customTheme])
+  }, [customTheme])
 
 
   useScript({

--- a/src/useFabraConnect.tsx
+++ b/src/useFabraConnect.tsx
@@ -1,31 +1,56 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import useScript from 'react-script-hook';
 
 declare global {
   interface Window { fabra: FabraConnect; }
 }
 
+export interface CustomTheme {
+  colors?: {
+    primary: {
+      base: string; // Primary theme color
+      hover: string; // Color when hovering over primary buttons
+      text: string; // Text color on top of the primary color
+    }
+  }
+}
+
 export interface FabraConnect {
-  open: (linkToken: string) => void;
+  initialize: ({ linkToken, customTheme} : { linkToken: string, customTheme?: CustomTheme }) => Promise<void>;
+  open: () => void;
   close: () => void;
 }
 
+
 export type UseFabraConnectResponse = {
-  open: (linkToken: string) => void;
+  open: (linkToken: string, customTheme?: CustomTheme) => void;
   close: () => void;
 };
 
-export const useFabraConnect = (): UseFabraConnectResponse => {
+export const useFabraConnect = ({ linkToken, customTheme } :{ linkToken: string, customTheme?: CustomTheme}): UseFabraConnectResponse => {
+  const [isFabraReady, setIsFabraReady] = useState<boolean>(false)
+
+  const initFabra = useCallback(async () => {
+    await window.fabra.initialize({
+      linkToken,
+      customTheme,
+    });
+    
+    setIsFabraReady(true);
+  }, [linkToken, customTheme])
+
+
   useScript({
     src: 'https://connect.fabra.io/initialize.js',
     checkForExisting: true,
+    onload: () => {
+      initFabra()
+    }
   });
 
   const open = useCallback((linkToken: string) => {
     if (window.fabra) {
-      window.fabra.open(linkToken);
-    } else {
-
+      window.fabra.open();
     }
   }, []);
 
@@ -33,5 +58,9 @@ export const useFabraConnect = (): UseFabraConnectResponse => {
     window.fabra.close();
   };
 
-  return { open, close };
+  return { 
+    open, 
+    close, 
+    // isReady: isFabraReady, // Can expose this if needed for loading states. Plaid does this for example.
+  };
 };

--- a/src/useFabraConnect.tsx
+++ b/src/useFabraConnect.tsx
@@ -16,8 +16,8 @@ export interface CustomTheme {
 }
 
 export interface FabraConnect {
-  initialize: ({ linkToken, customTheme} : { linkToken: string, customTheme?: CustomTheme }) => Promise<void>;
-  open: () => void;
+  initialize: ({  customTheme} : {  customTheme?: CustomTheme }) => Promise<void>;
+  open: (linkToken: string) => void;
   close: () => void;
 }
 
@@ -32,7 +32,6 @@ export const useFabraConnect = ({ linkToken, customTheme } :{ linkToken: string,
 
   const initFabra = useCallback(async () => {
     await window.fabra.initialize({
-      linkToken,
       customTheme,
     });
     
@@ -50,7 +49,7 @@ export const useFabraConnect = ({ linkToken, customTheme } :{ linkToken: string,
 
   const open = useCallback((linkToken: string) => {
     if (window.fabra) {
-      window.fabra.open();
+      window.fabra.open(linkToken);
     }
   }, []);
 


### PR DESCRIPTION
Two main changes:

* Changing the `useFabraConnect` API such that you now pass in `linkToken` and `theme` when you initialize the hook instead of when you call `open`. A caveat here is that I think something could be reworked about how if the linkToken changes, it ideally should also change the `connect` context.

* Using an `init` call that can keep track of if Fabra is loaded or not, aka if the frame is ready to show or not and can expose that to users.